### PR TITLE
Fix anchor scroll error

### DIFF
--- a/index.html
+++ b/index.html
@@ -3727,8 +3727,16 @@ Takk!`;
       // Smooth anchor scrolling
       document.querySelectorAll('a[href^="#"]').forEach((anchor) => {
         anchor.addEventListener("click", function (e) {
-          e.preventDefault();
           const targetId = this.getAttribute("href");
+
+          // Ignore empty hash links (e.g. href="#") which would
+          // otherwise cause querySelector to throw an error
+          if (!targetId || targetId === "#") {
+            e.preventDefault();
+            return;
+          }
+
+          e.preventDefault();
           const targetElement = document.querySelector(targetId);
           if (targetElement) {
             const targetOffset = targetElement.offsetTop - 80;


### PR DESCRIPTION
## Summary
- avoid calling `querySelector('#')` on links that just have `href="#"`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684d9386f9d88326a49a5d0b580f1e50