### PR TITLE
Fix smooth scroll anchor check

### DIFF
--- a/index.html
+++ b/index.html
@@ -3728,16 +3728,17 @@ Takk!`;
       document.querySelectorAll('a[href^="#"]').forEach((anchor) => {
         anchor.addEventListener("click", function (e) {
           const targetId = this.getAttribute("href");
-          if (targetId && targetId !== "#") {
-            e.preventDefault();
-            const targetElement = document.querySelector(targetId);
-            if (targetElement) {
-              const targetOffset = targetElement.offsetTop - 80;
-              window.scrollTo({
-                top: targetOffset,
-                behavior: "smooth",
-              });
-            }
+          // Skip if href is just "#"
+          if (targetId === "#") return;
+
+          e.preventDefault();
+          const targetElement = document.querySelector(targetId);
+          if (targetElement) {
+            const targetOffset = targetElement.offsetTop - 80;
+            window.scrollTo({
+              top: targetOffset,
+              behavior: "smooth",
+            });
           }
         });
       });


### PR DESCRIPTION
## Summary
- skip smooth scroll code for links with `href="#"`

## Testing
- `npm start` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d9513d7108326bf1463e65143f3b8