### PR TITLE
Fix smooth scroll skip '#' links

### DIFF
--- a/index.html
+++ b/index.html
@@ -3729,7 +3729,10 @@ Takk!`;
         anchor.addEventListener("click", function (e) {
           const targetId = this.getAttribute("href");
           // Skip if href is just "#"
-          if (targetId === "#") return;
+          if (targetId === "#") {
+            e.preventDefault();
+            return;
+          }
 
           e.preventDefault();
           const targetElement = document.querySelector(targetId);


### PR DESCRIPTION
## Summary
- handle anchor links with `href="#"` by preventing default and skipping scrolling

## Testing
- `npm start` (fails: unable to access network)

------
https://chatgpt.com/codex/tasks/task_e_684d9621a7ec83269b98cd7bc16f672f