### PR TITLE
Update guarantee and delivery times

### DIFF
--- a/index.html
+++ b/index.html
@@ -2264,8 +2264,9 @@
                   </div>
                   <h3>Premium Kvalitet</h3>
                   <p>
-                    Høyeste kvalitet med garanti. Vi refunderer 50% hvis vi ikke
-                    leverer som avtalt innen tidsfristen.
+                    Høyeste kvalitet med garanti. Rush 48&nbsp;timer, Prioritet
+                    72&nbsp;timer og Normal 128&nbsp;timer. Vi refunderer 50%
+                    hvis vi ikke leverer innen disse fristene.
                   </p>
                   <div class="pricing-feature-list">
                     <div class="pricing-feature">• Kvalitetsgaranti</div>
@@ -2309,7 +2310,11 @@
                     </div>
                     <div class="guarantee-text">
                       <strong>Lynanbeitet Garanti</strong>
-                      <span>50% refusjon ved forsinket levering</span>
+                      <span
+                        >Rush 48&nbsp;timer, Prioritet 72&nbsp;timer og Normal
+                        128&nbsp;timer – 50% refusjon hvis vi ikke leverer i
+                        tide</span
+                      >
                     </div>
                   </div>
                 </div>
@@ -2665,7 +2670,8 @@
             <div class="guarantee-banner">
               <div class="guarantee-title">Lynanbeitet Garanti</div>
               <div class="guarantee-text">
-                50% refusjon hvis vi ikke leverer innen avtalt tidsfrist!
+                Rush 48&nbsp;timer, Prioritet 72&nbsp;timer og Normal
+                128&nbsp;timer – 50% refusjon hvis vi ikke leverer i tide
               </div>
             </div>
 
@@ -2867,7 +2873,7 @@
                   <div class="timeline-row">
                     <span class="timeline-label">Estimert leveringstid:</span>
                     <span class="timeline-value" id="deliveryTime"
-                      >3-4 uker</span
+                      >72 timer</span
                     >
                   </div>
                 </div>
@@ -3303,19 +3309,19 @@
         // Update delivery time
         const deliveryTimes = {
           normal: {
-            simple: "2-3 uker",
-            standard: "3-4 uker",
-            advanced: "5-6 uker",
+            simple: "128 timer",
+            standard: "128 timer",
+            advanced: "128 timer",
           },
           priority: {
-            simple: "1-2 uker",
-            standard: "2-3 uker",
-            advanced: "3-4 uker",
+            simple: "72 timer",
+            standard: "72 timer",
+            advanced: "72 timer",
           },
           rush: {
-            simple: "3-5 dager",
-            standard: "1-2 uker",
-            advanced: "2-3 uker",
+            simple: "48 timer",
+            standard: "48 timer",
+            advanced: "48 timer",
           },
         };
 


### PR DESCRIPTION
## Summary
- update guarantee text to state 48/72/128 hour refund policy
- adjust delivery time label and dynamic delivery times in package builder

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684daa5d01788326b0f2da82c87a986a